### PR TITLE
Feature/keybind

### DIFF
--- a/src/app/user-interface/pages/configuration/settings/settings.html
+++ b/src/app/user-interface/pages/configuration/settings/settings.html
@@ -23,6 +23,16 @@
                 </span>
             </mcs-hint>
         </mcs-field>
+
+        <mcs-field data-mcssmall>
+            <span slot="text">Toggle Keybind</span>
+            <input id="mcs-settings-toggle-keybind" type="text" class="form-control" readonly />
+            <mcs-hint slot="hint">
+                <span data-mcsTooltipContent>Click the field and press a key or chord to set the toggle shortcut.</span>
+            </mcs-hint>
+        </mcs-field>
+
+        <div id="mcs-settings-toggle-keybind-feedback" class="mcs-settings-toggle-keybind-feedback">Shortcut ready.</div>
     </div>
 
     <mcs-dropdown id="mcs-gamemode" class="mcs-gamemode"></mcs-dropdown>

--- a/src/app/user-interface/pages/configuration/settings/settings.html
+++ b/src/app/user-interface/pages/configuration/settings/settings.html
@@ -28,7 +28,7 @@
             <span slot="text">Toggle Keybind</span>
             <input id="mcs-settings-toggle-keybind" type="text" class="form-control" readonly />
             <mcs-hint slot="hint">
-                <span data-mcsTooltipContent>Click the field and press a key or chord to set the toggle shortcut.</span>
+                <span data-mcsTooltipContent>Click the field and press a key to set the toggle shortcut.</span>
             </mcs-hint>
         </mcs-field>
 

--- a/src/app/user-interface/pages/configuration/settings/settings.scss
+++ b/src/app/user-interface/pages/configuration/settings/settings.scss
@@ -4,6 +4,38 @@ mcs-settings {
         flex-direction: column;
         gap: 10px;
         margin-bottom: 20px;
+
+        #mcs-settings-toggle-keybind {
+            &.mcs-is-capturing {
+                border-color: #3f8efc;
+                box-shadow: 0 0 0 1px #3f8efc;
+            }
+
+            &.mcs-is-invalid {
+                border-color: #e25d5d;
+                box-shadow: 0 0 0 1px #e25d5d;
+            }
+
+            &.mcs-is-valid {
+                border-color: #4aa76e;
+                box-shadow: 0 0 0 1px #4aa76e;
+            }
+        }
+
+        .mcs-settings-toggle-keybind-feedback {
+            min-height: 18px;
+            margin-top: -4px;
+            font-size: 12px;
+            color: #b8bec9;
+
+            &.mcs-is-invalid {
+                color: #e25d5d;
+            }
+
+            &.mcs-is-valid {
+                color: #4aa76e;
+            }
+        }
     }
 
     .mcs-settings-alternate-equipment-selector,

--- a/src/app/user-interface/pages/configuration/settings/settings.ts
+++ b/src/app/user-interface/pages/configuration/settings/settings.ts
@@ -8,6 +8,11 @@ import type { ExportDialog } from './export-dialog/export-dialog';
 import { Switch } from 'src/app/user-interface/_parts/switch/switch';
 import { Plotter } from 'src/app/user-interface/pages/simulate/plotter/plotter';
 import { StorageKey } from 'src/app/utils/account-storage';
+import {
+    DEFAULT_TOGGLE_PANEL_KEYBIND,
+    eventToShortcut,
+    normalizeShortcutInput
+} from 'src/app/utils/keyboard-shortcut';
 
 declare global {
     interface HTMLElementTagNameMap {
@@ -21,6 +26,8 @@ export class SettingsPage extends HTMLElement {
 
     private readonly _trials: HTMLInputElement;
     private readonly _ticks: HTMLInputElement;
+    private readonly _toggleKeybind: HTMLInputElement;
+    private readonly _toggleKeybindFeedback: HTMLDivElement;
     private readonly _alternateEquipmentSelector: Switch;
     private readonly _smallPlotter: Switch;
     private readonly _filterTargetDropdown: Switch;
@@ -32,6 +39,7 @@ export class SettingsPage extends HTMLElement {
     private readonly _exportDialog: ExportDialog;
 
     private _plotter: Plotter;
+    private _toggleKeybindFeedbackTimeout?: number;
 
     constructor() {
         super();
@@ -40,6 +48,12 @@ export class SettingsPage extends HTMLElement {
 
         this._trials = getElementFromFragment(this._content, 'mcs-settings-trials', 'input');
         this._ticks = getElementFromFragment(this._content, 'mcs-settings-ticks', 'input');
+        this._toggleKeybind = getElementFromFragment(this._content, 'mcs-settings-toggle-keybind', 'input');
+        this._toggleKeybindFeedback = getElementFromFragment(
+            this._content,
+            'mcs-settings-toggle-keybind-feedback',
+            'div'
+        );
         this._alternateEquipmentSelector = getElementFromFragment(
             this._content,
             'mcs-settings-alternate-equipment-selector',
@@ -70,6 +84,60 @@ export class SettingsPage extends HTMLElement {
 
         this._trials.oninput = event => this._onChange(event, 'trials');
         this._ticks.oninput = event => this._onChange(event, 'ticks');
+
+        const storedKeybind = Global.context.accountStorage.getItem(StorageKey.TogglePanelKeybind);
+        const toggleKeybind = normalizeShortcutInput(storedKeybind) ?? DEFAULT_TOGGLE_PANEL_KEYBIND;
+
+        this._toggleKeybind.value = toggleKeybind;
+        this._setToggleKeybindFeedback('Shortcut ready.', 'neutral');
+
+        if (!storedKeybind) {
+            Global.context.accountStorage.setItem(StorageKey.TogglePanelKeybind, toggleKeybind);
+            this._setToggleKeybindFeedback(`Default shortcut set to ${toggleKeybind}.`, 'valid', 1200);
+        }
+
+        this._toggleKeybind.onfocus = () => {
+            this._toggleKeybind.value = 'Press keys...';
+            this._toggleKeybind.select();
+            this._toggleKeybind.classList.add('mcs-is-capturing');
+            this._toggleKeybind.classList.remove('mcs-is-invalid', 'mcs-is-valid');
+            this._setToggleKeybindFeedback('Press any key or chord.', 'neutral');
+        };
+
+        this._toggleKeybind.onblur = () => {
+            this._toggleKeybind.value =
+                normalizeShortcutInput(Global.context.accountStorage.getItem(StorageKey.TogglePanelKeybind)) ??
+                DEFAULT_TOGGLE_PANEL_KEYBIND;
+
+            this._toggleKeybind.classList.remove('mcs-is-capturing');
+        };
+
+        this._toggleKeybind.onkeydown = event => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            const shortcut = eventToShortcut(event);
+
+            if (!shortcut) {
+                this._toggleKeybind.value =
+                    normalizeShortcutInput(Global.context.accountStorage.getItem(StorageKey.TogglePanelKeybind)) ??
+                    DEFAULT_TOGGLE_PANEL_KEYBIND;
+
+                this._toggleKeybind.classList.remove('mcs-is-valid');
+                this._toggleKeybind.classList.add('mcs-is-invalid');
+                this._setToggleKeybindFeedback('Invalid shortcut. Use at least one non-modifier key.', 'invalid', 1700);
+                return;
+            }
+
+            this._toggleKeybind.value = shortcut;
+            Global.context.accountStorage.setItem(StorageKey.TogglePanelKeybind, shortcut);
+
+            this._toggleKeybind.classList.remove('mcs-is-invalid');
+            this._toggleKeybind.classList.add('mcs-is-valid');
+            this._setToggleKeybindFeedback(`Shortcut saved: ${shortcut}.`, 'valid', 1400);
+
+            this._toggleKeybind.blur();
+        };
 
         const isAlternateEquipmentSelector =
             Global.context.accountStorage.getItem(StorageKey.AlternateEquipmentSelector) ??
@@ -222,6 +290,37 @@ export class SettingsPage extends HTMLElement {
         }
 
         callback();
+    }
+
+    private _setToggleKeybindFeedback(
+        message: string,
+        type: 'neutral' | 'valid' | 'invalid',
+        resetAfterMs?: number
+    ) {
+        if (this._toggleKeybindFeedbackTimeout) {
+            clearTimeout(this._toggleKeybindFeedbackTimeout);
+            this._toggleKeybindFeedbackTimeout = undefined;
+        }
+
+        this._toggleKeybindFeedback.textContent = message;
+        this._toggleKeybindFeedback.classList.remove('mcs-is-valid', 'mcs-is-invalid');
+
+        if (type === 'valid') {
+            this._toggleKeybindFeedback.classList.add('mcs-is-valid');
+        }
+
+        if (type === 'invalid') {
+            this._toggleKeybindFeedback.classList.add('mcs-is-invalid');
+        }
+
+        if (resetAfterMs && resetAfterMs > 0) {
+            this._toggleKeybindFeedbackTimeout = window.setTimeout(() => {
+                this._toggleKeybind.classList.remove('mcs-is-valid', 'mcs-is-invalid');
+                this._toggleKeybindFeedback.classList.remove('mcs-is-valid', 'mcs-is-invalid');
+                this._toggleKeybindFeedback.textContent = 'Shortcut ready.';
+                this._toggleKeybindFeedbackTimeout = undefined;
+            }, resetAfterMs);
+        }
     }
 }
 

--- a/src/app/user-interface/pages/configuration/settings/settings.ts
+++ b/src/app/user-interface/pages/configuration/settings/settings.ts
@@ -116,6 +116,17 @@ export class SettingsPage extends HTMLElement {
             event.preventDefault();
             event.stopPropagation();
 
+            if (event.key === 'Escape' || event.key === 'Esc') {
+                this._toggleKeybind.value =
+                    normalizeShortcutInput(Global.context.accountStorage.getItem(StorageKey.TogglePanelKeybind)) ??
+                    DEFAULT_TOGGLE_PANEL_KEYBIND;
+
+                this._toggleKeybind.classList.remove('mcs-is-valid', 'mcs-is-invalid');
+                this._setToggleKeybindFeedback('Shortcut capture cancelled.', 'neutral', 1200);
+                this._toggleKeybind.blur();
+                return;
+            }
+
             const shortcut = eventToShortcut(event);
 
             if (!shortcut) {

--- a/src/app/user-interface/pages/configuration/settings/settings.ts
+++ b/src/app/user-interface/pages/configuration/settings/settings.ts
@@ -101,7 +101,7 @@ export class SettingsPage extends HTMLElement {
             this._toggleKeybind.select();
             this._toggleKeybind.classList.add('mcs-is-capturing');
             this._toggleKeybind.classList.remove('mcs-is-invalid', 'mcs-is-valid');
-            this._setToggleKeybindFeedback('Press any key or chord.', 'neutral');
+            this._setToggleKeybindFeedback('Press any key.', 'neutral');
         };
 
         this._toggleKeybind.onblur = () => {

--- a/src/app/user-interface/user-interface.ts
+++ b/src/app/user-interface/user-interface.ts
@@ -14,6 +14,20 @@ import { Global } from '../global';
 export class UserInterface {
     public main!: Main;
     private readonly _onDocumentKeydown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape' || event.key === 'Esc') {
+            const isCapturingToggleKeybind =
+                document.activeElement instanceof HTMLInputElement &&
+                document.activeElement.id === 'mcs-settings-toggle-keybind' &&
+                document.activeElement.classList.contains('mcs-is-capturing');
+
+            if (!isCapturingToggleKeybind && this.main.isOpen) {
+                event.preventDefault();
+                this.main.toggle();
+            }
+
+            return;
+        }
+
         if (isEditableTarget(event.target)) {
             return;
         }

--- a/src/app/user-interface/user-interface.ts
+++ b/src/app/user-interface/user-interface.ts
@@ -2,12 +2,37 @@ import 'src/app/user-interface/elements';
 import './styles.scss';
 import type { Main } from './main/main';
 import { DialogController } from './_parts/dialog/dialog-controller';
+import { StorageKey } from '../utils/account-storage';
+import {
+    DEFAULT_TOGGLE_PANEL_KEYBIND,
+    doesEventMatchShortcut,
+    isEditableTarget,
+    normalizeShortcutInput
+} from '../utils/keyboard-shortcut';
+import { Global } from '../global';
 
 export class UserInterface {
-    public main: Main;
+    public main!: Main;
+    private readonly _onDocumentKeydown = (event: KeyboardEvent) => {
+        if (isEditableTarget(event.target)) {
+            return;
+        }
+
+        const shortcut =
+            normalizeShortcutInput(Global.context.accountStorage.getItem(StorageKey.TogglePanelKeybind)) ??
+            DEFAULT_TOGGLE_PANEL_KEYBIND;
+
+        if (!doesEventMatchShortcut(event, shortcut)) {
+            return;
+        }
+
+        event.preventDefault();
+        this.main.toggle();
+    };
 
     public init() {
         this.main = createElement('mcs-main', { classList: ['is-closed'] });
+        document.addEventListener('keydown', this._onDocumentKeydown);
 
         document.body.append(createElement('mcs-tooltip'));
         document.body.append(this.main);

--- a/src/app/utils/account-storage.ts
+++ b/src/app/utils/account-storage.ts
@@ -2,6 +2,7 @@ export enum StorageKey {
     AlternateEquipmentSelector = 'alternate-equipment-selector',
     SmallPlotter = 'small-plotter',
     FilterTargetDropdown = 'filter-target-dropdown',
+    TogglePanelKeybind = 'toggle-panel-keybind',
     Trials = 'trials',
     Ticks = 'ticks',
     PlotSkill = 'plot-skill',

--- a/src/app/utils/keyboard-shortcut.ts
+++ b/src/app/utils/keyboard-shortcut.ts
@@ -49,6 +49,10 @@ export function normalizeShortcutInput(value: string): string | null {
         }
 
         key = canonicalPart;
+
+        if (isDisallowedBindableKey(key)) {
+            return null;
+        }
     }
 
     if (!key) {
@@ -162,4 +166,8 @@ function canonicalizeKey(value: string): string | null {
 
 function isModifierKey(key: string): boolean {
     return key === 'Ctrl' || key === 'Alt' || key === 'Shift' || key === 'Meta';
+}
+
+function isDisallowedBindableKey(key: string): boolean {
+    return key === 'Escape';
 }

--- a/src/app/utils/keyboard-shortcut.ts
+++ b/src/app/utils/keyboard-shortcut.ts
@@ -1,0 +1,165 @@
+export const DEFAULT_TOGGLE_PANEL_KEYBIND = 'C';
+
+export function isEditableTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    return (
+        target.isContentEditable ||
+        target.closest('input, textarea, select, [contenteditable="true"], [contenteditable=""]') !== null
+    );
+}
+
+export function normalizeShortcutInput(value: string): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const parts = value
+        .split('+')
+        .map(part => part.trim())
+        .filter(Boolean);
+
+    if (!parts.length) {
+        return null;
+    }
+
+    const modifierSet = new Set(['Ctrl', 'Alt', 'Shift', 'Meta']);
+    const modifiers: string[] = [];
+    let key = '';
+
+    for (const part of parts) {
+        const canonicalPart = canonicalizeKey(part);
+
+        if (!canonicalPart) {
+            return null;
+        }
+
+        if (modifierSet.has(canonicalPart)) {
+            if (!modifiers.includes(canonicalPart)) {
+                modifiers.push(canonicalPart);
+            }
+
+            continue;
+        }
+
+        if (key) {
+            return null;
+        }
+
+        key = canonicalPart;
+    }
+
+    if (!key) {
+        return null;
+    }
+
+    const orderedModifiers = ['Ctrl', 'Alt', 'Shift', 'Meta'].filter(modifier => modifiers.includes(modifier));
+
+    return [...orderedModifiers, key].join('+');
+}
+
+export function eventToShortcut(event: KeyboardEvent): string | null {
+    const key = canonicalizeKey(event.key);
+
+    if (!key || isModifierKey(key)) {
+        return null;
+    }
+
+    const parts: string[] = [];
+
+    if (event.ctrlKey) {
+        parts.push('Ctrl');
+    }
+
+    if (event.altKey) {
+        parts.push('Alt');
+    }
+
+    if (event.shiftKey) {
+        parts.push('Shift');
+    }
+
+    if (event.metaKey) {
+        parts.push('Meta');
+    }
+
+    parts.push(key);
+
+    return normalizeShortcutInput(parts.join('+'));
+}
+
+export function doesEventMatchShortcut(event: KeyboardEvent, shortcut: string | null | undefined): boolean {
+    if (!shortcut) {
+        return false;
+    }
+
+    const normalizedShortcut = normalizeShortcutInput(shortcut);
+    const eventShortcut = eventToShortcut(event);
+
+    if (!normalizedShortcut || !eventShortcut) {
+        return false;
+    }
+
+    return normalizedShortcut === eventShortcut;
+}
+
+function canonicalizeKey(value: string): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const key = value.trim();
+
+    if (!key) {
+        return null;
+    }
+
+    if (key.length === 1) {
+        if (key === ' ') {
+            return 'Space';
+        }
+
+        return key.toUpperCase();
+    }
+
+    const aliases: Record<string, string> = {
+        Escape: 'Escape',
+        Esc: 'Escape',
+        Enter: 'Enter',
+        Tab: 'Tab',
+        Backspace: 'Backspace',
+        Delete: 'Delete',
+        Insert: 'Insert',
+        Home: 'Home',
+        End: 'End',
+        PageUp: 'PageUp',
+        PageDown: 'PageDown',
+        ArrowUp: 'ArrowUp',
+        ArrowDown: 'ArrowDown',
+        ArrowLeft: 'ArrowLeft',
+        ArrowRight: 'ArrowRight',
+        Space: 'Space',
+        Spacebar: 'Space',
+        Control: 'Ctrl',
+        Ctrl: 'Ctrl',
+        Alt: 'Alt',
+        Shift: 'Shift',
+        Meta: 'Meta'
+    };
+
+    if (aliases[key]) {
+        return aliases[key];
+    }
+
+    if (/^F([1-9]|1[0-2])$/i.test(key)) {
+        return key.toUpperCase();
+    }
+
+    return null;
+}
+
+function isModifierKey(key: string): boolean {
+    return key === 'Ctrl' || key === 'Alt' || key === 'Shift' || key === 'Meta';
+}


### PR DESCRIPTION
## Summary
This PR adds a configurable keyboard shortcut for opening/closing the Combat Simulator, plus improved Escape handling for both shortcut capture and panel closing.

<img width="1867" height="937" alt="image" src="https://github.com/user-attachments/assets/378ae0aa-6f61-48a7-8e52-9a7ef6fa89be" />

<img width="1808" height="932" alt="image" src="https://github.com/user-attachments/assets/f70896ad-2ac4-4b07-a2af-257588ce0488" />


## Changes
- Added stored setting for panel toggle shortcut:
  - account-storage.ts
- Added keyboard shortcut utility module:
  - keyboard-shortcut.ts
  - Includes normalization, event matching, and editable-target checks
- Added keybind field to Settings UI with feedback states:
  - settings.html
  - settings.scss
  - settings.ts
- Added global keydown listener for panel toggle shortcut:
  - user-interface.ts

## Escape Key Behavior
- While recording a new shortcut:
  - `Escape` cancels capture
  - Existing shortcut is restored
  - `Escape` is not saved as a bindable key
- Outside shortcut recording:
  - `Escape` closes the Combat Simulator panel when open

## UX Notes
- Default shortcut is `C` if no stored value exists
- Shortcut capture includes visual feedback (`capturing`, `valid`, `invalid`)
- Global shortcut does not trigger while typing in editable inputs

## Validation
- Built successfully with webpack (`npx webpack`) after changes.


